### PR TITLE
Adds support for older SAm and SAL lights

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -96,6 +96,9 @@
           "title": "Mode",
           "type": "string",
           "enum": [
+            "Pool Color Set",
+            "Pool Color Sync",
+            "Pool Color Swim",
             "Pool Mode Party",
             "Pool Mode Romance",
             "Pool Mode Caribbean",

--- a/src/setColorAccessory.ts
+++ b/src/setColorAccessory.ts
@@ -10,6 +10,9 @@ import ScreenLogic from 'node-screenlogic'
 import { ScreenLogicPlatform, AccessoryAdaptor } from './platform'
 
 const setColorConfig = [
+  { name: 'Pool Color Set', cmd: ScreenLogic.LIGHT_CMD_COLOR_SET },
+  { name: 'Pool Color Sync', cmd: ScreenLogic.LIGHT_CMD_COLOR_SYNC },
+  { name: 'Pool Color Swim', cmd: ScreenLogic.LIGHT_CMD_COLOR_SWIM },
   { name: 'Pool Mode Party', cmd: ScreenLogic.LIGHT_CMD_COLOR_MODE_PARTY },
   { name: 'Pool Mode Romance', cmd: ScreenLogic.LIGHT_CMD_COLOR_MODE_ROMANCE },
   { name: 'Pool Mode Caribbean', cmd: ScreenLogic.LIGHT_CMD_COLOR_MODE_CARIBBEAN },


### PR DESCRIPTION
Older lights do not support the modes listed in the configuration. This change adds the “Color Set”, “Color Swim”, and “Color Sync” options those lights use and allows them to be set up as switches similar to the original light modes.